### PR TITLE
fix: Configure Netlify for correct deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  base    = "frontend"
+  command = "npm run build"
+  publish = "dist"
+
+[context.production.environment]
+  NODE_VERSION = "18"


### PR DESCRIPTION
Adds a `netlify.toml` file to configure the build settings for Netlify. This should resolve the "Page not found" error by specifying the correct base directory, build command, and publish directory for the frontend application.