### PR TITLE
fix(auth): refactor login to use standard supabase auth

### DIFF
--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -22,7 +22,7 @@ export default function Login() {
 
     // Log system status for debugging
     console.log('🎆 EVITA Sistema de Gestión cargado')
-    console.log('🚀 Demo disponible: admin@evita.com / evita123')
+    console.log('🚀 Demo disponible: test@example.com / password123')
     console.log('📄 Current user state:', user)
   }, [user, navigate])
 

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,90 +1,54 @@
 import { supabase } from '../lib/supabaseClient';
-import bcrypt from 'bcryptjs';
 
-// Fallback user for demo purposes
-const fallbackUser = {
-  id: '00000000-0000-0000-0000-000000000000',
-  email: 'admin@evita.com',
-  passwordHash: bcrypt.hashSync('evita123', 10), // Ensure you have a fallback password
-  username: 'Admin',
-};
-
+/**
+ * Logs in a user using their email and password.
+ * This now uses the standard Supabase Auth method.
+ * @param {string} email - The user's email.
+ * @param {string} password - The user's password.
+ * @returns {Promise<{session: object | null, error: object | null}>}
+ */
 export const login = async (email, password) => {
-  try {
-    const { data, error } = await supabase
-      .from('usuarios_app')
-      .select('*')
-      .eq('email', email)
-      .single();
-
-    if (error || !data) {
-      // Fallback to hardcoded user if not found in DB
-      if (email === fallbackUser.email && bcrypt.compareSync(password, fallbackUser.passwordHash)) {
-        const session = {
-          user: { id: fallbackUser.id, email: fallbackUser.email, username: fallbackUser.username },
-          token: 'fake-fallback-token',
-        };
-        localStorage.setItem('session', JSON.stringify(session));
-        return { session, error: null };
-      }
-      return { session: null, error: 'Invalid login credentials' };
-    }
-
-    const passwordMatch = await bcrypt.compare(password, data.password);
-    if (passwordMatch) {
-      const session = {
-        user: { id: data.id, email: data.email, username: data.username || data.email.split('@')[0] },
-        token: 'fake-supabase-token', // In a real scenario, you would use Supabase's session
-      };
-      localStorage.setItem('session', JSON.stringify(session));
-      return { session, error: null };
-    }
-
-    return { session: null, error: 'Invalid login credentials' };
-  } catch (error) {
-    console.error('Login error:', error);
-    return { session: null, error: 'An unexpected error occurred' };
-  }
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+  return { session: data.session, error };
 };
 
+/**
+ * Logs out the current user.
+ * This signs the user out from the Supabase session.
+ * @returns {Promise<{error: object | null}>}
+ */
 export const logout = async () => {
-  localStorage.removeItem('session');
-  // Also sign out from Supabase if you are using its auth session
-  await supabase.auth.signOut();
+  const { error } = await supabase.auth.signOut();
+  return { error };
 };
 
-export const getSession = () => {
-  const session = localStorage.getItem('session');
-  return session ? JSON.parse(session) : null;
+/**
+ * Gets the current session from Supabase.
+ * @returns {Promise<{session: object | null, error: object | null}>}
+ */
+export const getSession = async () => {
+  const { data, error } = await supabase.auth.getSession();
+  return { session: data.session, error };
 };
 
-export const register = async (email, password, username) => {
-  try {
-    const { data: existingUser, error: fetchError } = await supabase
-      .from('usuarios_app')
-      .select('email')
-      .eq('email', email)
-      .single();
-
-    if (existingUser) {
-      return { user: null, error: 'User already exists' };
-    }
-
-    const passwordHash = await bcrypt.hash(password, 10);
-
-    const { data: newUser, error: insertError } = await supabase
-      .from('usuarios_app')
-      .insert([{ email, password: passwordHash, username }])
-      .select()
-      .single();
-
-    if (insertError) {
-      throw insertError;
-    }
-
-    return { user: newUser, error: null };
-  } catch (error) {
-    console.error('Registration error:', error);
-    return { user: null, error: 'Failed to register user' };
-  }
+/**
+ * Registers a new user.
+ * This uses the standard Supabase Auth method for signing up.
+ * @param {string} email - The new user's email.
+ * @param {string} password - The new user's password.
+ * @param {object} options - Additional metadata for the user.
+ * @returns {Promise<{user: object | null, error: object | null}>}
+ */
+export const register = async (email, password, options = {}) => {
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: options, // e.g., { username: 'example' }
+    },
+  });
+  return { user: data.user, error };
 };


### PR DESCRIPTION
This commit refactors the entire authentication flow to address a broken login system. The previous implementation used a flawed, insecure custom logic to query the database and compare passwords on the client-side.

The key changes are:
- Replaced the custom login logic in `authService.js` with `supabase.auth.signInWithPassword`.
- Removed the insecure fallback user and client-side password comparison.
- Updated `AuthContext.jsx` to use `supabase.auth.onAuthStateChange` for robust, real-time session management.
- Added a `.env.local` file to store the Supabase credentials, which were previously missing.
- Updated the demo user credentials to `test@example.com` / `password123` as requested.

This resolves the "Invalid login credentials" error and establishes a secure, standard authentication pattern for the application.