### PR TITLE
fix(prospectos): Eliminar funciones duplicadas en PaginaProspectos.jsx

### DIFF
--- a/frontend/src/pages/PaginaProspectos.jsx
+++ b/frontend/src/pages/PaginaProspectos.jsx
@@ -61,20 +61,6 @@ const formatUserDisplay = (user) => {
 };
 import FormularioProspecto from '../components/prospectos/FormularioProspecto';
 
-const safeParse = (value) => {
-  try {
-    return JSON.parse(value);
-  } catch (error) {
-    return null;
-  }
-};
-
-const formatUserDisplay = (user) => {
-  if (!user) return '-';
-  const value = typeof user === 'string' ? safeParse(user) : user;
-  return value?.full_name || value?.nombre || value?.email || value?.id || '-';
-};
-
 // Configuración de colores para estados
 const estadoColores = {
   'Nuevo': 'info',


### PR DESCRIPTION
Se eliminaron las declaraciones duplicadas de las funciones `safeParse` y `formatUserDisplay` en el archivo `frontend/src/pages/PaginaProspectos.jsx`.

Estas funciones duplicadas causaban un error de compilación en Netlify, impidiendo el despliegue de la aplicación. La eliminación de estas duplicaciones resuelve el error y permite que el proceso de compilación se complete con éxito.